### PR TITLE
fix: dashboard Google sign-in popup fallback (#263)

### DIFF
--- a/src/oncofiles/dashboard.html
+++ b/src/oncofiles/dashboard.html
@@ -1377,7 +1377,9 @@
             if (typeof google !== 'undefined' && google.accounts) {
               google.accounts.id.initialize({
                 client_id: cfg.client_id,
-                callback: handleGoogleCredential
+                callback: handleGoogleCredential,
+                ux_mode: 'popup',
+                use_fedcm_for_prompt: true
               });
               google.accounts.id.renderButton(
                 document.getElementById('g_id_signin'),
@@ -2963,9 +2965,11 @@
       });
 
       // File upload handler
-      fileInput.addEventListener('change', function() {
-        if (fileInput.files.length > 0) handleImage(fileInput.files[0]);
-      });
+      if (fileInput) {
+        fileInput.addEventListener('change', function() {
+          if (fileInput.files.length > 0) handleImage(fileInput.files[0]);
+        });
+      }
 
       fab.addEventListener('click', function() {
         overlay.style.display = 'flex';


### PR DESCRIPTION
## Summary
- Added `ux_mode: 'popup'` and `use_fedcm_for_prompt: true` to Google Identity Services initialization — ensures sign-in completes via popup fallback when FedCM is unavailable (browser automation, incognito, third-party cookie blocks)
- Fixed `bug-file` null reference TypeError that threw on every dashboard page load

## Investigation
The GIS button code was correct (`handleGoogleCredential` callback properly wired), but FedCM silently fails in certain environments. No JS errors, no network calls to `/dashboard/verify` — the Google callback simply never fires. Adding `ux_mode: 'popup'` provides a reliable fallback.

## Test plan
- [x] `uv run pytest` — 648 passed
- [x] `uv run ruff check` — all checks passed
- [ ] Verify sign-in works on production after deploy
- [ ] Verify no console errors on dashboard page load

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)