### PR TITLE
feat(mcp): Option A MVP — patient_slug on patient.py tools (unblock #424 biomarker update)

### DIFF
--- a/src/oncofiles/tools/_helpers.py
+++ b/src/oncofiles/tools/_helpers.py
@@ -120,6 +120,44 @@ def _get_patient_id(*, required: bool = True) -> str:
     return pid
 
 
+async def _resolve_patient_id(
+    patient_slug: str | None,
+    ctx: Context,
+    *,
+    required: bool = True,
+) -> str:
+    """Resolve patient identity for a tool call (Option A per #429).
+
+    Stateless-HTTP safe: every patient-scoped tool should accept a
+    `patient_slug` parameter and resolve via this helper. Falls back to the
+    middleware-resolved current patient when slug is omitted (preserves
+    backwards-compat for bearer-token flows where the token already binds
+    a specific patient).
+
+    ACL: the caller's bearer token + the middleware's rate-limit + token→patient
+    binding still apply — if a caller's token maps to patient X and they pass
+    `patient_slug=Y` for someone else's patient, this currently allows it
+    (same as pre-Option-A behaviour). A stricter ACL check (caller ∈
+    allowed_callers_for(patient_id)) belongs in a follow-up once the
+    caller_identity plumbing is in place.
+
+    Args:
+        patient_slug: Explicit slug from the caller (e.g. 'q1b'). Preferred.
+        ctx: FastMCP request context.
+        required: If True (default), raises ValueError when neither slug nor
+            middleware-resolved patient is available.
+    """
+    if patient_slug:
+        db = _get_db(ctx)
+        patient = await db.get_patient_by_slug(patient_slug)
+        if not patient:
+            raise ValueError(
+                f"Patient not found: {patient_slug!r}. Use list_patients() to see available slugs."
+            )
+        return patient.patient_id
+    return _get_patient_id(required=required)
+
+
 def _get_db(ctx: Context) -> Database:
     return ctx.request_context.lifespan_context["db"]
 

--- a/src/oncofiles/tools/patient.py
+++ b/src/oncofiles/tools/patient.py
@@ -7,18 +7,24 @@ import json
 from fastmcp import Context
 
 from oncofiles import patient_context
-from oncofiles.tools._helpers import _get_db, _get_patient_id
+from oncofiles.tools._helpers import _get_db, _get_patient_id, _resolve_patient_id
 
 
-async def get_patient_context(ctx: Context) -> str:
+async def get_patient_context(ctx: Context, patient_slug: str | None = None) -> str:
     """Get the current patient clinical context.
 
     Returns structured patient data including diagnosis, biomarkers,
     treatment, metastases, comorbidities, and excluded therapies.
+
+    Args:
+        patient_slug: Optional — explicit patient slug (e.g. 'q1b'). Required
+            in stateless HTTP contexts (Claude.ai connector, ChatGPT) where
+            select_patient() state does not persist across tool calls (#429).
+            Stdio + single-patient bearer flows can omit.
     """
     from oncofiles.tools._helpers import _with_clinical_disclaimer
 
-    pid = _get_patient_id()
+    pid = await _resolve_patient_id(patient_slug, ctx)
     # Try loading from DB if not cached yet
     ctx_data = patient_context.get_context(pid)
     if not ctx_data or not ctx_data.get("name"):
@@ -32,6 +38,7 @@ async def get_patient_context(ctx: Context) -> str:
 async def update_patient_context(
     ctx: Context,
     updates_json: str,
+    patient_slug: str | None = None,
 ) -> str:
     """Update specific fields in the patient clinical context.
 
@@ -42,6 +49,9 @@ async def update_patient_context(
     Args:
         updates_json: JSON object with fields to update. Example:
             '{"treatment": {"current_cycle": 3}}'
+        patient_slug: Optional — explicit patient slug (e.g. 'q1b'). Required
+            in stateless HTTP contexts (Claude.ai connector, ChatGPT) where
+            select_patient() state does not persist across tool calls (#429).
     """
     try:
         updates = json.loads(updates_json)
@@ -51,7 +61,7 @@ async def update_patient_context(
     if not isinstance(updates, dict):
         return json.dumps({"error": "updates_json must be a JSON object"})
 
-    pid = _get_patient_id()
+    pid = await _resolve_patient_id(patient_slug, ctx)
     updated = patient_context.update_context(updates, patient_id=pid)
     db = _get_db(ctx)
     await patient_context.save_to_db(db.db, updated, patient_id=pid)
@@ -61,6 +71,7 @@ async def update_patient_context(
             "status": "updated",
             "updated_fields": list(updates.keys()),
             "patient_name": updated.get("name", ""),
+            "patient_slug": patient_slug or "current",
         }
     )
 


### PR DESCRIPTION
## Summary

- Implements Option A from #429 on the two tools needed to unblock q1b biomarker persistence: \`get_patient_context\` + \`update_patient_context\` now accept \`patient_slug: str | None = None\`
- Adds \`_resolve_patient_id(patient_slug, ctx)\` helper in \`tools/_helpers.py\` — resolves slug → patient_id via existing \`db.get_patient_by_slug\`; falls back to middleware-resolved current patient when slug omitted (backwards-compat for bearer flows)
- Docstrings call out that slug is required in stateless HTTP contexts (Claude.ai connector, ChatGPT)

## Unblocks

- **#424 q1b biomarker update** — after deploy, Claude.ai can call \`update_patient_context(updates_json='{...KRAS G12S...}', patient_slug='q1b')\` in one shot, no select_patient dance

## Not in this PR (explicit follow-ups)

- \`list_patients\`, \`select_patient\` — bootstrapping tools, no slug semantics
- Remaining ~50 patient-scoped tools across \`documents\` / \`treatment\` / \`conversations\` / \`research\` / \`activity\` / \`lab_trends\` / \`naming\` / \`hygiene\` / \`enhance_tools\` / \`gdrive\` / \`agent_state\` — each gets the same \`patient_slug\` signature in subsequent batches. Tracker issue will follow
- Stricter ACL (caller ∈ allowed_callers_for(patient_id)) — needs caller_identity plumbing

## Test plan

- [x] \`uv run pytest tests/test_patient_context.py tests/test_patient_isolation.py\` — 27 pass
- [ ] After deploy: from Claude.ai, call \`get_patient_context(patient_slug='q1b')\` and verify biomarkers return q1b (not default)
- [ ] Same Claude.ai session: \`update_patient_context(updates_json='{...}', patient_slug='q1b')\` — verify persists
- [ ] Regression: stdio transport without slug still returns default patient (backwards-compat)

## Linked
- #429 (session state bug — this is the fix)
- #424 (biomarker update — this unblocks)
- #408 (pre-existing select_patient is_current — related design debt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)